### PR TITLE
fix: user object is passed as a parameter

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -1615,9 +1615,9 @@ class FileListDataType(BaseDataType):
             if user is True:
                 user_is_reviewer = True
             elif user:
-                if hasattr(parameters.user, "userprofile") is not True:
-                    models.UserProfile.objects.create(user=parameters.user)
-                user_is_reviewer = user_is_resource_reviewer(parameters.user)
+                if hasattr(user, "userprofile") is not True:
+                    models.UserProfile.objects.create(user=user)
+                user_is_reviewer = user_is_resource_reviewer(user)
             else:
                 # There must be a user to be able to upload files.
                 return


### PR DESCRIPTION
Relates to permission framework changes. Attempting to save a file would through an error saying user does not exist on parameters. It is now being passed a parameter.