### PR TITLE
Fix: Bool datatype save error - string conversion 

### DIFF
--- a/arches/app/utils/string_utils.py
+++ b/arches/app/utils/string_utils.py
@@ -1,7 +1,7 @@
 def str_to_bool(value):
     match value:
-        case "y" | "yes" | "t" | "true" | "on" | "1":
+        case "y" | "yes" | "t" | "true" | "on" | "1" | "True":
             return True
-        case "n" | "no" | "f" | "false" | "off" | "0":
+        case "n" | "no" | "f" | "false" | "off" | "0" | "False":
             return False
     raise ValueError


### PR DESCRIPTION
### Description

Validation for the boolean datatype was converting a string value to a bool through a utility.
The utility did not include capitalised 'False', 'True' values so was throwing an error.
Added additional string options to fix this