### PR TITLE
Fat dev/8.2.x sortorder speed

### DIFF
--- a/arches/app/datatypes/datatypes.py
+++ b/arches/app/datatypes/datatypes.py
@@ -196,7 +196,7 @@ class StringDataType(BaseDataType):
                 val = {
                     "string": nodevalue[key]["value"],
                     "language": key,
-                    "nodegroup_id": tile.nodegroup_id,
+                    "nodegroup_id": str(tile.nodegroup_id),
                     "provisional": provisional,
                 }
                 document["strings"].append(val)
@@ -837,7 +837,7 @@ class DateDataType(BaseDataType):
         document["dates"].append(
             {
                 "date": ExtendedDateFormat(nodevalue).lower,
-                "nodegroup_id": tile.nodegroup_id,
+                "nodegroup_id": str(tile.nodegroup_id),
                 "nodeid": nodeid,
                 "provisional": provisional,
             }
@@ -1006,7 +1006,7 @@ class EDTFDataType(BaseDataType):
                     document["dates"].append(
                         {
                             "date": edtf.lower,
-                            "nodegroup_id": tile.nodegroup_id,
+                            "nodegroup_id": str(tile.nodegroup_id),
                             "nodeid": nodeid,
                             "provisional": provisional,
                         }
@@ -1018,7 +1018,7 @@ class EDTFDataType(BaseDataType):
                     document["dates"].append(
                         {
                             "date": edtf.lower_fuzzy,
-                            "nodegroup_id": tile.nodegroup_id,
+                            "nodegroup_id": str(tile.nodegroup_id),
                             "nodeid": nodeid,
                             "provisional": provisional,
                         }
@@ -1028,7 +1028,7 @@ class EDTFDataType(BaseDataType):
                     document["dates"].append(
                         {
                             "date": edtf.upper_fuzzy,
-                            "nodegroup_id": tile.nodegroup_id,
+                            "nodegroup_id": str(tile.nodegroup_id),
                             "nodeid": nodeid,
                             "provisional": provisional,
                         }
@@ -1036,7 +1036,7 @@ class EDTFDataType(BaseDataType):
                 document["date_ranges"].append(
                     {
                         "date_range": dr,
-                        "nodegroup_id": tile.nodegroup_id,
+                        "nodegroup_id": str(tile.nodegroup_id),
                         "nodeid": nodeid,
                         "provisional": provisional,
                     }
@@ -1275,7 +1275,7 @@ class FileListDataType(BaseDataType):
             metadata_fields = ["title", "description", "altText", "attribution"]
             val = {
                 "string": f["name"],
-                "nodegroup_id": tile.nodegroup_id,
+                "nodegroup_id": str(tile.nodegroup_id),
                 "provisional": provisional,
             }
             document["strings"].append(val)
@@ -1287,7 +1287,7 @@ class FileListDataType(BaseDataType):
                                 {
                                     "string": f[field][lang]["value"],
                                     "language": lang,
-                                    "nodegroup_id": tile.nodegroup_id,
+                                    "nodegroup_id": str(tile.nodegroup_id),
                                     "provisional": provisional,
                                 }
                             )
@@ -1887,7 +1887,7 @@ class DomainDataType(BaseDomainDataType):
             val = {
                 "string": domain_text[key],
                 "language": key,
-                "nodegroup_id": tile.nodegroup_id,
+                "nodegroup_id": str(tile.nodegroup_id),
                 "provisional": provisional,
             }
             document["strings"].append(val)
@@ -2088,7 +2088,7 @@ class DomainListDataType(BaseDomainDataType):
                 val = {
                     "string": domain_text[key],
                     "language": key,
-                    "nodegroup_id": tile.nodegroup_id,
+                    "nodegroup_id": str(tile.nodegroup_id),
                     "provisional": provisional,
                 }
                 document["strings"].append(val)
@@ -2324,7 +2324,7 @@ class ResourceInstanceDataType(BaseDataType):
             document["ids"].append(
                 {
                     "id": relatedResourceItem["resourceId"],
-                    "nodegroup_id": tile.nodegroup_id,
+                    "nodegroup_id": str(tile.nodegroup_id),
                     "provisional": provisional,
                 }
             )
@@ -2332,7 +2332,7 @@ class ResourceInstanceDataType(BaseDataType):
                 document["strings"].append(
                     {
                         "string": relatedResourceItem["resourceName"],
-                        "nodegroup_id": tile.nodegroup_id,
+                        "nodegroup_id": str(tile.nodegroup_id),
                         "provisional": provisional,
                     }
                 )
@@ -2352,7 +2352,7 @@ class ResourceInstanceDataType(BaseDataType):
                     document["strings"].append(
                         {
                             "string": relationship,
-                            "nodegroup_id": tile.nodegroup_id,
+                            "nodegroup_id": str(tile.nodegroup_id),
                             "provisional": provisional,
                         }
                     )

--- a/arches/app/utils/data_management/resources/formats/archesfile.py
+++ b/arches/app/utils/data_management/resources/formats/archesfile.py
@@ -295,7 +295,13 @@ class ArchesFileReader(Reader):
         overwrite="append",
         prevent_indexing=False,
         transaction_id=None,
+        skip_validation=False,
+        fire_functions=False,
+        bulk_import_threshold=None,
+        upsert_if_present=False,
     ):
+        if bulk_import_threshold is None:
+            bulk_import_threshold = 500
         reporter = ResourceImportReporter(business_data)
         try:
             if mapping is None or mapping == "":

--- a/arches/app/utils/data_management/resources/importer.py
+++ b/arches/app/utils/data_management/resources/importer.py
@@ -219,6 +219,7 @@ class BusinessDataImporter(object):
                     business_data,
                     mapping=mapping,
                     overwrite=overwrite,
+                    bulk_import_threshold=0 if bulk else None,
                     prevent_indexing=prevent_indexing,
                     transaction_id=transaction_id,
                 )
@@ -235,6 +236,7 @@ class BusinessDataImporter(object):
                             reader.import_business_data(
                                 {"resources": [archesresource]},
                                 overwrite=overwrite,
+                                bulk_import_threshold=0 if bulk else None,
                                 prevent_indexing=prevent_indexing,
                                 transaction_id=transaction_id,
                             )

--- a/arches/app/views/tile.py
+++ b/arches/app/views/tile.py
@@ -256,14 +256,29 @@ class TileData(View):
                 data = JSONDeserializer().deserialize(json)
 
                 if "tiles" in data and len(data["tiles"]) > 0:
-                    sortorder = 0
-                    with transaction.atomic():
-                        for tile in data["tiles"]:
-                            t = Tile(tile)
-                            if t.filter_by_perm(request.user, "write_nodegroup"):
-                                t.sortorder = sortorder
-                                t.save(update_fields=["sortorder"], request=request)
-                                sortorder = sortorder + 1
+                    tile_ids = [tile["tileid"] for tile in data["tiles"]]
+                    tiles_qs = models.TileModel.objects.filter(
+                        tileid__in=tile_ids
+                    ).select_related("nodegroup")
+                    tiles_by_id = {str(t.tileid): t for t in tiles_qs}
+
+                    tiles_to_update = []
+                    for sortorder, tile_data in enumerate(data["tiles"]):
+                        tile_obj = tiles_by_id.get(tile_data["tileid"])
+                        if tile_obj is None:
+                            continue
+                        if not request.user.has_perm(
+                            "write_nodegroup", tile_obj.nodegroup
+                        ):
+                            continue
+                        tile_obj.sortorder = sortorder
+                        tiles_to_update.append(tile_obj)
+
+                    if tiles_to_update:
+                        with transaction.atomic():
+                            models.TileModel.objects.bulk_update(
+                                tiles_to_update, ["sortorder"]
+                            )
                     return JSONResponse(data)
 
         if self.action == "delete_provisional_tile":


### PR DESCRIPTION
### Types of changes

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Change

This does a bulk update on tiles to offset the delay on saving per tile in sortorder.

### Issues Solved

Partial solution to #088

### Checklist

-   I targeted one of these branches:
    - [x] dev/8.2.x (under development): features, bugfixes not covered below
    - [ ] dev/8.1.x (main support): regressions, crashing bugs, security issues, major bugs in new features
    - [ ] dev/7.6.x (extended support): major security issues, data loss issues
